### PR TITLE
load globally polyfill for regeneratorRuntime

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,3 +1,4 @@
+import 'regenerator-runtime/runtime';
 import './index.css';
 import '../../root/css/jquery-ui.min.css';
 import '../../root/css/main.css';

--- a/package-lock.json
+++ b/package-lock.json
@@ -8121,10 +8121,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
-      "dev": true
+      "version": "0.13.6",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.6.tgz",
+      "integrity": "sha512-GmwlGiazQEbOwQWDdbbaP10i15pGtScYWLbMZuu+RKRz0cZ+g8IUONazBnaZqe7j1670IV1HgE4/8iy7CQPf4Q=="
     },
     "regenerator-transform": {
       "version": "0.14.5",

--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
     "hooks": {
       "pre-commit": "npx lint-staged"
     }
+  },
+  "dependencies": {
+    "regenerator-runtime": "0.13.6"
   }
 }


### PR DESCRIPTION
Hi @sthtnr you are right that `client/` needs @babel/polyfill. I'm loading `regenerator-runtime/runtime` which applies polyfill for  the generatorRuntime globally, due to @babel/polyfill is deprecated: https://babeljs.io/docs/en/babel-polyfill .

Please let me know if this works for you. Thanks!